### PR TITLE
⚠️ Warning: update public SECURITY.md reporting instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Report security vulnerabilities to the Trimble Cybersecurity team at:
 
-    https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form
+<https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form>
 
 Report security vulnerabilities in third-party modules to the person or team maintaining the module.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,9 @@
 
 ## Reporting a Vulnerability
 
-Security issues and bugs should be reported privately, via email, to cybersecurity@trimble.com.
+Report security vulnerabilities to the Trimble Cybersecurity team at:
 
-If you do not receive a response within 24 hours, please follow up via email to ensure we received your original message.
+    https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form
 
-Please do not open issues for anything you think might have a security implication.
+Report security vulnerabilities in third-party modules to the person or team maintaining the module.
+


### PR DESCRIPTION
⚠️ **Warning:** this is a proactive compliance update ahead of [trimble-oss/oss-overseer#170](https://github.com/trimble-oss/oss-overseer/pull/170).

## Why this PR exists
A public policy update is queued in `oss-overseer` that will require public repositories to do both of the following in `SECURITY.md`:

1. Include the Trimble public security form URL:

       https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form

2. Stop using `cybersecurity@trimble.com`, which is for internal use only.

## What this PR changes
- updates the `Reporting a Vulnerability` section to point to the approved public form
- removes the internal-only email address
- leaves the rest of the file unchanged

## Why this matters
If [trimble-oss/oss-overseer#170](https://github.com/trimble-oss/oss-overseer/pull/170) merges before this repo updates `SECURITY.md`, the next public audit will report a new **MUST** violation for this repository.

This PR is meant as an early warning and a low-noise fix before that rollout happens.